### PR TITLE
만화 읽어 올때 상대 경로로 처리되어 정상 표시 되지 않는 케이스가 있습니다.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -206,7 +206,14 @@ def GetPhotoAlbum(url, title):
         page = HTTP.Request(url, {'method':'GET'}, headers=HEADERS).content
         imgs = RE_IMGURL.findall(page)
 
-    for idx, img_url in enumerate(imgs):
+    url_parts = url.split('//', 1)
+    base_url = url_parts[0]+'//'+url_parts[1].split('/', 1)[0]
+    idx = 0
+    for idx2, img_url in enumerate(imgs):
+        if img_url.endswith('iframe'):
+            continue
+        if not img_url.startswith('http'):
+            img_url = base_url + img_url
         Log.Debug(img_url)
         oc.add(
             PhotoObject(
@@ -216,6 +223,7 @@ def GetPhotoAlbum(url, title):
                 thumb = img_url,
                 items = [MediaObject(parts=[PartObject(key=img_url)])]
             ))
+        idx = idx + 1
 
     return oc
 


### PR DESCRIPTION
안녕하세요
plex 서버 설치중에 좋은 plugin이 있어서 사용하려 하니 이미지가 나오지 않아 간단하게 수정했습니다.

jpg 경로가 상대 경로라 최소한의 의존성을 위해 main url에서 잘라 붙이는 방법인데 더 좋은 방법이 있으면 구현 부탁드립니다.

또한 iframe이라는 놈이 첫 페이지로 나와 iframe으로 끝나는 놈도 skip하게 바꾸었습니다.

참고후 반영 부탁드립니다.